### PR TITLE
try to fix the publish issue

### DIFF
--- a/src/WorksOnMyMachine/DotNetBuild.sh
+++ b/src/WorksOnMyMachine/DotNetBuild.sh
@@ -1,4 +1,3 @@
 ﻿
 dotnet restore
-dotnet build
-dotnet publish -c Release -o ./app/ WorksOnMyMachine
+dotnet publish -c Release

--- a/src/WorksOnMyMachine/docker-compose.yml
+++ b/src/WorksOnMyMachine/docker-compose.yml
@@ -2,8 +2,7 @@ version: '2'
 
 services:
   worksonmymachine:
-    build:
-      context: ..
-      dockerfile: app/dockerfile
+    image:
+      weidazhao/worksonmymachine
     ports:
       - "80:80"

--- a/src/WorksOnMyMachine/dockerfile
+++ b/src/WorksOnMyMachine/dockerfile
@@ -1,8 +1,9 @@
 FROM microsoft/dotnet:1.0.0-rc2-core
 
-# Copy the app
-COPY /app /app
 WORKDIR /app
+
+# Copy the app
+COPY ./bin/Release/netcoreapp1.0/publish/ .
 
 # Configure the listening port to 80
 ENV ASPNETCORE_URLS http://*:80


### PR DESCRIPTION
It turns out DotNet CLI seems to have a bug. When output is specified, publishOptions.includes are not honored, so wwwroot, Views and appsettings.json are not copied.
